### PR TITLE
bug: fix radio

### DIFF
--- a/example/RadioTest.tsx
+++ b/example/RadioTest.tsx
@@ -1,0 +1,47 @@
+import React, { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+
+const RadioTest = () => {
+  const { register, setValue, reset, getValues } = useForm();
+  useEffect(() => {
+    console.log('effect');
+    reset({
+      atype: 'DETAILED',
+    });
+    // setTimeout(() => { setValue('atype', 'DETAILED') }, 500)
+  }, [reset]);
+  console.log('getValues: ', getValues());
+  return (
+    <form>
+      <div className="flex-1">
+        <div>
+          <div className="flex gap-4 flex-wrap">
+            <label htmlFor="atype.SIMPLE">
+              <input
+                type="radio"
+                className="radio-xs"
+                id="atype.SIMPLE"
+                value="SIMPLE"
+                {...register('atype')}
+              />
+              <span className="label-text">SIMPLE</span>
+            </label>
+
+            <label htmlFor="atype.DETAILED">
+              <input
+                type="radio"
+                className="radio-xs"
+                id="atype.DETAILED"
+                value="DETAILED"
+                {...register('atype')}
+              />
+              <span className="label-text">DETAILED</span>
+            </label>
+          </div>
+        </div>
+      </div>
+    </form>
+  );
+};
+
+export default RadioTest;

--- a/src/AutoForm.tsx
+++ b/src/AutoForm.tsx
@@ -7,6 +7,7 @@ import ErrorAlert from './common/ErrorAlert';
 import { form2Proto, proto2Form } from './protobuf/conversion';
 import { AutoFormContext, AutoFormProvider } from './context';
 import AutoFormField from './AutoFormField';
+import { fillInitialValues } from './protobuf/conversion/initial';
 
 export type AutoFormProps<T = any> = {
   namespace: protobuf.Namespace;
@@ -54,8 +55,9 @@ const AutoForm = <T,>(props: AutoFormProps<T>) => {
     if (!(initialState && reflectionObj)) return;
 
     const formState = proto2Form(context)(initialState, reflectionObj, options);
+    fillInitialValues(formState, reflectionObj);
     console.log('Initial state decoded', formState);
-    methods.reset(formState as Record<string, {}>);
+    methods.reset(formState);
   }, [initialState, reflectionObj]);
 
   if (!reflectionObj) {

--- a/src/AutoForm.tsx
+++ b/src/AutoForm.tsx
@@ -55,7 +55,6 @@ const AutoForm = <T,>(props: AutoFormProps<T>) => {
     if (!(initialState && reflectionObj)) return;
 
     const formState = proto2Form(context)(initialState, reflectionObj, options);
-    fillInitialValues(formState, reflectionObj);
     console.log('Initial state decoded', formState);
     methods.reset(formState);
   }, [initialState, reflectionObj]);
@@ -72,7 +71,7 @@ const AutoForm = <T,>(props: AutoFormProps<T>) => {
         <form
           {...rest}
           onSubmit={methods.handleSubmit((values) => {
-            console.log('Raw values : ', values);
+            console.log('AutoForm Submitted : ', values);
             onSubmitValid?.(
               form2Proto(context)(values, reflectionObj, options),
             );

--- a/src/common/RadioButton.tsx
+++ b/src/common/RadioButton.tsx
@@ -14,7 +14,6 @@ const RadioButton: React.FC<Props> = ({
   name,
   label = value,
   disabled,
-  defaultChecked = false,
 }) => {
   const { register } = useFormContext();
   const id = `${name}.${value}`;
@@ -30,7 +29,6 @@ const RadioButton: React.FC<Props> = ({
         id={id}
         value={value}
         disabled={disabled}
-        defaultChecked={defaultChecked}
         {...register(name)}
       />
       <span className="label-text">{label}</span>

--- a/src/protobuf/OneofField.tsx
+++ b/src/protobuf/OneofField.tsx
@@ -17,10 +17,12 @@ export const isProto3Optional = (oneof: protobuf.OneOf) =>
 
 const OneofField: React.FC<OneofProps> = ({ parentName, oneof, options }) => {
   const { fieldOptions } = useChildFields(options);
-  const { watch } = useFormContext();
+  const { watch, getValues, setValue } = useFormContext();
   const oneofFullName = parentName ? `${parentName}.${oneof.name}` : oneof.name;
-  // TODO: find out why default value does not work
-  const selected = watch(oneofFullName) ?? oneof.fieldsArray[0].name;
+  if (!getValues(oneofFullName)) {
+    setValue(oneofFullName, oneof.fieldsArray[0].name);
+  }
+  const selected = watch(oneofFullName);
 
   return (
     <div>
@@ -42,7 +44,7 @@ const OneofField: React.FC<OneofProps> = ({ parentName, oneof, options }) => {
       ))}
       {isProto3Optional(oneof) && (
         <div className="my-2">
-          <RadioButton name={oneofFullName} label="None" />
+          <RadioButton name={oneofFullName} label="None" value="__unset__" />
         </div>
       )}
     </div>

--- a/src/protobuf/OneofField.tsx
+++ b/src/protobuf/OneofField.tsx
@@ -30,7 +30,6 @@ const OneofField: React.FC<OneofProps> = ({ parentName, oneof, options }) => {
             value={f.name}
             name={oneofFullName}
             label={fieldOptions[f.name]?.label}
-            defaultChecked={selected === f.name}
           />
           {selected === f.name && (
             <Input

--- a/src/protobuf/conversion/initial.ts
+++ b/src/protobuf/conversion/initial.ts
@@ -97,7 +97,7 @@ function getInitialMessageValue(type: protobuf.Type) {
   }
 }
 
-function getInitialEnumValue(enumType: protobuf.Enum) {
+export function getInitialEnumValue(enumType: protobuf.Enum) {
   return Object.entries(enumType.valuesById)[0][1];
 }
 

--- a/src/protobuf/conversion/initial.ts
+++ b/src/protobuf/conversion/initial.ts
@@ -10,14 +10,14 @@ export const getInitialValue = (field: protobuf.Field) => {
   if (field.resolvedType instanceof protobuf.Type) {
     return getInitialMessageValue(field.resolvedType);
   }
+  if (field.resolvedType instanceof protobuf.Enum) {
+    return getInitialEnumValue(field.resolvedType);
+  }
   if (!isUnset(field.defaultValue)) {
     return field.defaultValue;
   }
   if (!isUnset(field.typeDefault)) {
     return field.typeDefault;
-  }
-  if (field.resolvedType instanceof protobuf.Enum) {
-    return getInitialEnumValue(field.resolvedType);
   }
   throw new Error('Unknown type: ' + field);
 };
@@ -98,8 +98,7 @@ function getInitialMessageValue(type: protobuf.Type) {
 }
 
 function getInitialEnumValue(enumType: protobuf.Enum) {
-  const name = Object.keys(enumType.valuesById)[0];
-  return enumType.values[name];
+  return Object.entries(enumType.valuesById)[0][1];
 }
 
 function isUnset(value: unknown) {

--- a/src/protobuf/conversion/proto2Form.ts
+++ b/src/protobuf/conversion/proto2Form.ts
@@ -1,3 +1,4 @@
+import protobuf from 'protobufjs';
 import { type ConvertValue, createConverter } from './convert';
 import type { MapElement, RepeatedElement } from '../../models';
 
@@ -15,6 +16,11 @@ const decodeValue: ConvertValue = (decode, value, field, options) => {
         $value: decode($value, field.resolvedType, options),
       }),
     );
+  } else if (
+    field.resolvedType instanceof protobuf.Enum &&
+    !Number.isNaN(Number(value))
+  ) {
+    return field.resolvedType.valuesById[Number(value)];
   }
   return decode(value, field.resolvedType, options);
 };

--- a/src/protobuf/input/primitive/Enum.tsx
+++ b/src/protobuf/input/primitive/Enum.tsx
@@ -3,6 +3,7 @@ import protobuf from 'protobufjs';
 import { useFormContext } from 'react-hook-form';
 import RadioButton from '../../../common/RadioButton';
 import { FieldOptions } from '../../../models';
+import { getInitialEnumValue } from '../../conversion/initial';
 
 interface Props {
   type: protobuf.Enum;
@@ -10,14 +11,11 @@ interface Props {
   options?: FieldOptions;
 }
 
-const getDefaultSelected = (type: protobuf.Enum) => {
-  const firstId = Number(Object.keys(type.valuesById)[0]);
-  return type.valuesById[firstId];
-};
-
 const EnumInput: React.FC<Props> = ({ type, name, options }) => {
-  const { watch } = useFormContext();
-  const selected = watch(name) ?? getDefaultSelected(type);
+  const { getValues, setValue } = useFormContext();
+  if (!getValues(name)) {
+    setValue(name, getInitialEnumValue(type));
+  }
 
   return (
     <div className="flex gap-4 flex-wrap">

--- a/src/protobuf/input/primitive/Enum.tsx
+++ b/src/protobuf/input/primitive/Enum.tsx
@@ -28,7 +28,6 @@ const EnumInput: React.FC<Props> = ({ type, name, options }) => {
           name={name}
           key={label}
           disabled={options?.disabled}
-          defaultChecked={selected === label}
         />
       ))}
     </div>


### PR DESCRIPTION
### What's changed

- do not use `defaultChecked` props of input. Seems like it somehow breaks the sync between VDOM and DOM when  used with `reset`.

- always use `string` value for `Enum`
    - `proto2Form` converts number type enum value into string type.
    - `getInitialEnumValue` returns string value.

-  A component representing `oneof` and `Enum` now call `setValue` itself if the value chosen doesn't exist.