### PR TITLE
bug: react element should not be shared between different oneof case

### DIFF
--- a/.changeset/nine-pandas-bake.md
+++ b/.changeset/nine-pandas-bake.md
@@ -1,0 +1,5 @@
+---
+"protobuf-auto-form": patch
+---
+
+bug: react element should not be shared between different oneof cases

--- a/packages/core/src/protobuf/OneofField.tsx
+++ b/packages/core/src/protobuf/OneofField.tsx
@@ -59,6 +59,7 @@ const OneofField: React.FC<OneofProps> = ({ parentName, oneof, options }) => {
         </select>
 
         <Input
+          key={selectedField.name}
           name={join(parentName, selectedField.name)}
           field={selectedField}
           options={fieldOptions[selectedField.name]}
@@ -79,6 +80,7 @@ const OneofField: React.FC<OneofProps> = ({ parentName, oneof, options }) => {
             />
             {selected === f.name && (
               <Input
+                key={f.name}
                 name={join(parentName, f.name)}
                 field={f}
                 options={fieldOptions[f.name]}


### PR DESCRIPTION
### Describe the invalid behavior

- In dropdown `OneOf` mode, if each case have same element shape, the rendered content is kept between each case selection.
- This leads to mismatch between rendered and submitted form state (**critical bug**).